### PR TITLE
Fix for #19 script engine classloading issue

### DIFF
--- a/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
+++ b/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
@@ -91,7 +91,7 @@ public class JavaClassGeneratorMojo extends AbstractMojo {
 
     private Map<String, Map<String, String>> extractContracts(String result) throws MojoExecutionException {
         try {
-            ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
+            ScriptEngine engine = new ScriptEngineManager(null).getEngineByName("nashorn");
             String script = "JSON.parse(JSON.stringify(" + result + "))";
             Map<String, Object> json = (Map<String, Object>) engine.eval(script);
             Map<String, Map<String, String>> contracts = (Map<String, Map<String, String>>) json.get("contracts");


### PR DESCRIPTION
With some versions of the JDK, the classloading of script engines does not pick up the Nashorn engine built into the JDK, and returns a null script engine.

This tells the JDK to use its internal classloading to pick up the Nashorn engine, and is much more reliable across different JDK versions / architectures.