### PR TITLE
Support path mapping to solc

### DIFF
--- a/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
+++ b/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
@@ -93,6 +93,7 @@ public class JavaClassGeneratorMojo extends AbstractMojo {
                 String metadataScript = "JSON.parse(JSON.stringify(" + metadata + "))";
                 Map<String, Object> metadataJson = (Map<String, Object>) engine.eval(metadataScript);
                 Object settingsMap = metadataJson.get("settings");
+                // FIXME this generates java files for interfaces with >org.ethereum:solcJ-all:0.5.2 , because the compiler generates now metadata.
                 if (settingsMap != null) {
                     Map<String, String> compilationTarget = ((Map<String, Map<String, String>>) settingsMap).get("compilationTarget");
                     if (compilationTarget != null) {

--- a/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
+++ b/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
@@ -59,6 +59,9 @@ public class JavaClassGeneratorMojo extends AbstractMojo {
     @Parameter(property = "nativeJavaType", defaultValue = "true")
     protected boolean nativeJavaType;
 
+    @Parameter(property = "pathPrefixes")
+    protected String[] pathPrefixes = new String[0];
+
     @Parameter(property = "outputFormat", defaultValue = DEFAULT_OUTPUT_FORMAT)
     protected String outputFormat;
 
@@ -72,45 +75,39 @@ public class JavaClassGeneratorMojo extends AbstractMojo {
     }
 
     private Map<String, Map<String, String>> extractContracts(String result) throws MojoExecutionException {
-        try {
-            ScriptEngine engine = new ScriptEngineManager(null).getEngineByName("nashorn");
-            String script = "JSON.parse(JSON.stringify(" + result + "))";
-            Map<String, Object> json = (Map<String, Object>) engine.eval(script);
-            Map<String, Map<String, String>> contracts = (Map<String, Map<String, String>>) json.get("contracts");
-            if (contracts == null) {
-                getLog().warn("no contracts found");
-                return null;
+        JsonParser jsonParser = new JsonParser();
+        Map<String, Object> json = jsonParser.parseJson(result);
+        Map<String, Map<String, String>> contracts = (Map<String, Map<String, String>>) json.get("contracts");
+        if (contracts == null) {
+            getLog().warn("no contracts found");
+            return null;
+        }
+        Map<String, String> contractRemap = new HashMap<>();
+        for (String contractFilename : contracts.keySet()) {
+            Map<String, String> contractMetadata = contracts.get(contractFilename);
+            String metadata = contractMetadata.get("metadata");
+            if (metadata == null || metadata.length() == 0) {
+                contracts.remove(contractFilename);
+                continue;
             }
-            Map<String, String> contractRemap = new HashMap<>();
-            for (String contractFilename : contracts.keySet()) {
-                Map<String, String> contractMetadata = contracts.get(contractFilename);
-                String metadata = contractMetadata.get("metadata");
-                if (metadata == null || metadata.length() == 0) {
-                    contracts.remove(contractFilename);
-                    continue;
-                }
-                getLog().debug("metadata:" + metadata);
-                String metadataScript = "JSON.parse(JSON.stringify(" + metadata + "))";
-                Map<String, Object> metadataJson = (Map<String, Object>) engine.eval(metadataScript);
-                Object settingsMap = metadataJson.get("settings");
-                // FIXME this generates java files for interfaces with >org.ethereum:solcJ-all:0.5.2 , because the compiler generates now metadata.
-                if (settingsMap != null) {
-                    Map<String, String> compilationTarget = ((Map<String, Map<String, String>>) settingsMap).get("compilationTarget");
-                    if (compilationTarget != null) {
-                        for (Map.Entry<String, String> entry : compilationTarget.entrySet()) {
-                            String value = entry.getValue();
-                            contractRemap.put(contractFilename, value);
-                        }
+            getLog().debug("metadata:" + metadata);
+            Map<String, Object> metadataJson = jsonParser.parseJson(metadata);
+            Object settingsMap = metadataJson.get("settings");
+            // FIXME this generates java files for interfaces with >org.ethereum:solcJ-all:0.5.2 , because the compiler generates now metadata.
+            if (settingsMap != null) {
+                Map<String, String> compilationTarget = ((Map<String, Map<String, String>>) settingsMap).get("compilationTarget");
+                if (compilationTarget != null) {
+                    for (Map.Entry<String, String> entry : compilationTarget.entrySet()) {
+                        String value = entry.getValue();
+                        contractRemap.put(contractFilename, value);
                     }
                 }
-                Map<String, String> compiledContract = contracts.remove(contractFilename);
-                String contractName = contractRemap.get(contractFilename);
-                contracts.put(contractName, compiledContract);
             }
-            return contracts;
-        } catch (ScriptException e) {
-            throw new MojoExecutionException("Could not parse SolC result", e);
+            Map<String, String> compiledContract = contracts.remove(contractFilename);
+            String contractName = contractRemap.get(contractFilename);
+            contracts.put(contractName, compiledContract);
         }
+        return contracts;
     }
 
     private String parseSoliditySources(Collection<String> includedFiles) throws MojoExecutionException {

--- a/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
+++ b/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
@@ -116,6 +116,7 @@ public class JavaClassGeneratorMojo extends AbstractMojo {
         CompilerResult result = SolidityCompiler.getInstance(getLog()).compileSrc(
                 soliditySourceFiles.getDirectory(),
                 includedFiles,
+                pathPrefixes,
                 SolidityCompiler.Options.ABI,
                 SolidityCompiler.Options.BIN,
                 SolidityCompiler.Options.INTERFACE,

--- a/src/main/java/org/web3j/mavenplugin/JsonParser.java
+++ b/src/main/java/org/web3j/mavenplugin/JsonParser.java
@@ -1,0 +1,27 @@
+package org.web3j.mavenplugin;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import java.util.Map;
+
+public class JsonParser {
+
+    private final ScriptEngine engine;
+
+    public JsonParser() {
+        engine = new ScriptEngineManager(null).getEngineByName("nashorn");
+    }
+
+    public Map<String, Object> parseJson(String jsonString) throws MojoExecutionException {
+        try {
+            String script = "JSON.parse(JSON.stringify(" + jsonString + "))";
+            return  (Map<String, Object>) engine.eval(script);
+        } catch (
+                ScriptException e) {
+            throw new MojoExecutionException("Could not parse SolC result", e);
+        }
+    }
+}

--- a/src/test/java/org/web3j/mavenplugin/IssueITest.java
+++ b/src/test/java/org/web3j/mavenplugin/IssueITest.java
@@ -90,7 +90,7 @@ public class IssueITest {
         SolidityCompiler solidityCompiler = SolidityCompiler.getInstance(new SystemStreamLog());
         Set<String> sources = Collections.singleton("issue-09.sol");
 
-        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", sources, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
+        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", sources, new String[0], SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
 
         assertFalse(compilerResult.isFailed());
     }

--- a/src/test/java/org/web3j/mavenplugin/JavaClassGeneratorITest.java
+++ b/src/test/java/org/web3j/mavenplugin/JavaClassGeneratorITest.java
@@ -94,6 +94,53 @@ public class JavaClassGeneratorITest {
         assertEquals("Main, Upper and Util Class", 3, files.size());
     }
 
+
+    @Test
+    public void pomWithImportWithPath() throws Exception {
+        File pom = new File(resources.getBasedir("import-with-path"), "pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JavaClassGeneratorMojo mojo = (JavaClassGeneratorMojo) mojoRule.lookupMojo("generate-sources", pom);
+        assertNotNull(mojo);
+
+        mojo.sourceDestination = testFolder.getRoot().getPath();
+        mojo.outputFormat = "java";
+        mojo.execute();
+
+        Path path = Paths.get(mojo.sourceDestination);
+
+        List<Path> files = Files
+                .find(path, 99, (p, bfa) -> bfa.isRegularFile())
+                .filter(file -> file.toString().endsWith("java"))
+                .collect(Collectors.toList());
+        assertEquals("Main and Dependency Class", 2, files.size());
+    }
+
+
+
+    @Test
+    public void pomWithImportWithPathWithSpaces() throws Exception {
+        File pom = new File(resources.getBasedir("import-with-path-with-spaces"), "pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        JavaClassGeneratorMojo mojo = (JavaClassGeneratorMojo) mojoRule.lookupMojo("generate-sources", pom);
+        assertNotNull(mojo);
+
+        mojo.sourceDestination = testFolder.getRoot().getPath();
+        mojo.outputFormat = "java";
+        mojo.execute();
+
+        Path path = Paths.get(mojo.sourceDestination);
+
+        List<Path> files = Files
+                .find(path, 99, (p, bfa) -> bfa.isRegularFile())
+                .filter(file -> file.toString().endsWith("java"))
+                .collect(Collectors.toList());
+        assertEquals("Main and Dependency Class", 2, files.size());
+    }
+
     @Test
     public void pomWithoutConfiguration() throws Exception {
         File pom = new File(resources.getBasedir("valid"), "default.pom.xml");

--- a/src/test/java/org/web3j/mavenplugin/solidity/SolidityCompilerTest.java
+++ b/src/test/java/org/web3j/mavenplugin/solidity/SolidityCompilerTest.java
@@ -18,7 +18,7 @@ public class SolidityCompilerTest {
     public void compileContract() throws Exception {
         Set<String> source = Collections.singleton("Greeter.sol");
 
-        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", source, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
+        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", source, new String[0], SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
 
         assertFalse(compilerResult.errors, compilerResult.isFailed());
         assertTrue(compilerResult.errors, compilerResult.errors.isEmpty());
@@ -36,7 +36,7 @@ public class SolidityCompilerTest {
     public void invalidContractSyntax() throws Exception {
         Set<String> source = Collections.singleton("Greeter-invalid-syntax.sol");
 
-        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", source, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
+        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", source, new String[0], SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
 
         assertTrue(compilerResult.isFailed());
         assertFalse(compilerResult.errors.isEmpty());
@@ -47,7 +47,7 @@ public class SolidityCompilerTest {
     public void invalidContractVersion() throws Exception {
         Set<String> source = Collections.singleton("Greeter-invalid-version.sol");
 
-        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", source, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
+        CompilerResult compilerResult = solidityCompiler.compileSrc("src/test/resources/", source, new String[0], SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
 
         assertTrue(compilerResult.isFailed());
         assertFalse(compilerResult.errors.isEmpty());

--- a/src/test/projects/import-with-path-with-spaces/pom.xml
+++ b/src/test/projects/import-with-path-with-spaces/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zuehlke.bc</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Mojo Test Project</name>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.web3j</groupId>
+                <artifactId>web3j-maven-plugin</artifactId>
+                <version>4.0.3-SNAPSHOT</version>
+                <configuration>
+                    <packageName>model</packageName>
+                    <sourceDestination>src/test/generated</sourceDestination>
+                    <soliditySourceFiles>
+                        <directory>src/test/resources/import-with-path/with-spaces</directory>
+                        <includes>
+                            <include>**/*.sol</include>
+                        </includes>
+                    </soliditySourceFiles>
+                    <pathPrefixes>
+                        <pathPrefix>dep spaced=../dependencies with spaces</pathPrefix>
+                    </pathPrefixes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/projects/import-with-path/pom.xml
+++ b/src/test/projects/import-with-path/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zuehlke.bc</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Mojo Test Project</name>
+
+
+    <properties>
+        <dependency-folder>../dependencies</dependency-folder>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.web3j</groupId>
+                <artifactId>web3j-maven-plugin</artifactId>
+                <version>4.0.3-SNAPSHOT</version>
+                <configuration>
+                    <packageName>model</packageName>
+                    <sourceDestination>src/test/generated</sourceDestination>
+                    <soliditySourceFiles>
+                        <directory>src/test/resources/import-with-path/contracts</directory>
+                        <includes>
+                            <include>**/*.sol</include>
+                        </includes>
+                    </soliditySourceFiles>
+                    <pathPrefixes>
+                        <pathPrefix>dep=../dependencies</pathPrefix>
+                    </pathPrefixes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/EmptyContract.sol
+++ b/src/test/resources/EmptyContract.sol
@@ -1,1 +1,1 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;

--- a/src/test/resources/Greeter-invalid-syntax.sol
+++ b/src/test/resources/Greeter-invalid-syntax.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 class mortal {
 }

--- a/src/test/resources/Greeter.sol
+++ b/src/test/resources/Greeter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity >=0.4.23 <0.6.0;
 
 /* Example from https://www.ethereum.org/greeter */
 contract mortal {
@@ -9,7 +9,7 @@ contract mortal {
     constructor () public {owner = msg.sender;}
 
     /* Function to recover the funds on the contract */
-    function kill() public {if (msg.sender == owner) selfdestruct(owner);}
+    function kill() public {if (msg.sender == owner) selfdestruct(msg.sender);}
 }
 
 
@@ -18,12 +18,12 @@ contract greeter is mortal {
     string greeting;
 
     /* this runs when the contract is executed */
-    constructor(string _greeting) public {
+    constructor(string memory _greeting) public {
         greeting = _greeting;
     }
 
     /* main function */
-    function greet() public constant returns (string) {
+    function greet() public view returns (string memory) {
         return greeting;
     }
 }

--- a/src/test/resources/import-with-path/contracts/Main.sol
+++ b/src/test/resources/import-with-path/contracts/Main.sol
@@ -1,0 +1,12 @@
+pragma solidity >=0.4.23 <0.6.0;
+
+import "dep/Dependency.sol";
+
+contract Main {
+    address creator;
+
+    constructor () public {
+        creator = msg.sender;
+    }
+
+}

--- a/src/test/resources/import-with-path/dependencies with spaces/Dependency.sol
+++ b/src/test/resources/import-with-path/dependencies with spaces/Dependency.sol
@@ -1,0 +1,9 @@
+pragma solidity >=0.4.19 <0.6.0;
+
+contract Dependency {
+    address creator;
+
+    constructor() public {
+        creator = msg.sender;
+    }
+}

--- a/src/test/resources/import-with-path/dependencies/Dependency.sol
+++ b/src/test/resources/import-with-path/dependencies/Dependency.sol
@@ -1,0 +1,9 @@
+pragma solidity >=0.4.19 <0.6.0;
+
+contract Dependency {
+    address creator;
+
+    constructor() public {
+        creator = msg.sender;
+    }
+}

--- a/src/test/resources/import-with-path/with-spaces/Main.sol
+++ b/src/test/resources/import-with-path/with-spaces/Main.sol
@@ -1,0 +1,12 @@
+pragma solidity >=0.4.23 <0.6.0;
+
+import "dep spaced/Dependency.sol";
+
+contract Main {
+    address creator;
+
+    constructor () public {
+        creator = msg.sender;
+    }
+
+}

--- a/src/test/resources/import/Main.sol
+++ b/src/test/resources/import/Main.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity >=0.4.23 <0.6.0;
 
 import "./sub/Util.sol";
 

--- a/src/test/resources/import/Upper.sol
+++ b/src/test/resources/import/Upper.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 contract Upper {
     address creator;
 
-    constructor() {
+    constructor() public{
         creator = msg.sender;
     }
 

--- a/src/test/resources/import/sub/Util.sol
+++ b/src/test/resources/import/sub/Util.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 import "../Upper.sol";
 
 contract Util {
     address creator;
 
-    constructor() {
+    constructor() public{
         creator = msg.sender;
     }
 }

--- a/src/test/resources/issue-09.sol
+++ b/src/test/resources/issue-09.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 
 library ConvertLib {

--- a/src/test/resources/issue-13.sol
+++ b/src/test/resources/issue-13.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 /**
  * 
@@ -12,7 +12,7 @@ contract Predictor {
     }
 
     // returns an int array by adding to all its elements a scalar value "a"
-    function subtractScalar(int[] self, int a) public pure returns (int[] s) {
+    function subtractScalar(int[] memory self, int a) public pure returns (int[] memory s) {
         s = new int[](self.length);
         for (uint i = 0; i < self.length; i++)
             s[i] = self[i] - a;

--- a/src/test/resources/issue-17/Issue17relative2.sol
+++ b/src/test/resources/issue-17/Issue17relative2.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 contract Issue17relative2 {
     address creator;
 
-    constructor() {
+    constructor() public {
         creator = msg.sender;
     }
 

--- a/src/test/resources/issue-17/issue17import1.sol
+++ b/src/test/resources/issue-17/issue17import1.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 contract Issue17import1 {
     address creator;
 
-    constructor() {
+    constructor() public{
         creator = msg.sender;
     }
 

--- a/src/test/resources/issue-17/issue17import2.sol
+++ b/src/test/resources/issue-17/issue17import2.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 contract Issue17import2 {
     address creator;
 
-    constructor() {
+    constructor() public {
         creator = msg.sender;
     }
 

--- a/src/test/resources/issue-17/issue17main.sol
+++ b/src/test/resources/issue-17/issue17main.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 import "./issue17import1.sol";
 import "./issue17import2.sol";
@@ -7,7 +7,7 @@ import "./pkg1/Issue17relative1.sol";
 contract Issue17main {
     address creator;
 
-    constructor() {
+    constructor() public {
         creator = msg.sender;
     }
 

--- a/src/test/resources/issue-17/pkg1/Issue17relative1.sol
+++ b/src/test/resources/issue-17/pkg1/Issue17relative1.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity >=0.4.19 <0.6.0;
 
 import "../Issue17relative2.sol";
 

--- a/src/test/resources/issue-23/Inter.sol
+++ b/src/test/resources/issue-23/Inter.sol
@@ -1,7 +1,7 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 interface InterCheck {
-    function check() public;
+    function check() external;
 }
 
 contract ChecImpl is InterCheck {

--- a/src/test/resources/issue-23/InterAlone.sol
+++ b/src/test/resources/issue-23/InterAlone.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.19;
+pragma solidity >=0.4.19 <0.6.0;
 
 interface NoImplementationInterfaceCheck {
-    function check() public;
+    function check() external;
 }
 


### PR DESCRIPTION
### What does this PR do?

Adding a new parameter 'pathPrefixes' to specify path mappings to solc.
### Where should the reviewer start?

org.web3j.mavenplugin.JavaClassGeneratorITest#pomWithImportWithPath()
### Why is it needed?

If the project has contract dependencies imported, which where installed by npm, the location of the dependencies can be specified.