### PR TITLE
add abiSourceFiles support, add outputJavaParentContractClassName…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ The are several variable to select the solidity source files, define a source de
 | `<sourceDestination/>` | relative or absolute path of the generated files (java, bin, abi)                      | `src/main/java`                 |
 | `<outputFormat/>`      | generate Java Classes(`java`), ABI(`abi`) and/or BIN (`bin`) Files (comma separated)   | `java`                          |
 | `<nativeJavaType/>`    | Creates Java Native Types (instead of Solidity Types)                                  | `true`                          |
+| `<outputJavaParentContractClassName/>` | Sets custom(? extends org.web3j.tx.Contract) class as a parent for java generated code | `org.web3j.tx.Contract` |
 | `<soliditySourceFiles>`| Standard maven [fileset](https://maven.apache.org/shared/file-management/fileset.html) | `<soliditySourceFiles>`<br>`  <directory>src/main/resources</directory>`<br>`  <includes>`<br>`    <include>**/*.sol</include>`<br>`  </includes>`<br>`</soliditySourceFiles>`  |
+| `<abiSourceFiles>`     | Standard maven [fileset](https://maven.apache.org/shared/file-management/fileset.html) | `<abiSourceFiles>`<br>`  <directory>src/main/resources</directory>`<br>`  <includes>`<br>`    <include>**/*.json</include>`<br>`  </includes>`<br>`</abiSourceFiles>`           |
 | `<contract>`           | Filter (`<include>` or `<exclude>`) contracts based on the name.                       | `<contract>`<br>`  <includes>`<br>`    <include>greeter</include>`<br>`  </includes>`<br>`  <excludes>`<br>`    <exclude>mortal</exclude>`<br>`  <excludes>`<br>`</contracts>`  |
 | `<pathPrefixes>`       | A list (`<pathPrefixe>`) of replacements of dependency replacements inside Solidity contract.  |  |
 
@@ -69,6 +71,12 @@ Create a standard java maven project. Add following `<plugin>` - configuration i
                 <include>**/*.sol</include>
             </includes>
         </soliditySourceFiles>
+        <abiSourceFiles>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>**/*.json</include>
+            </includes>
+        </abiSourceFiles>
         <outputDirectory>
             <java>src/java/generated</java>
             <bin>src/bin/generated</bin>

--- a/src/test/java/org/web3j/mavenplugin/JavaClassGeneratorMojoTest.java
+++ b/src/test/java/org/web3j/mavenplugin/JavaClassGeneratorMojoTest.java
@@ -2,8 +2,6 @@ package org.web3j.mavenplugin;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class JavaClassGeneratorMojoTest {
 
     private JavaClassGeneratorMojo generator = new JavaClassGeneratorMojo();

--- a/src/test/java/org/web3j/mavenplugin/SampleCustomContract.java
+++ b/src/test/java/org/web3j/mavenplugin/SampleCustomContract.java
@@ -1,0 +1,13 @@
+package org.web3j.mavenplugin;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.tx.Contract;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.gas.ContractGasProvider;
+
+public abstract class SampleCustomContract extends Contract {
+
+    protected SampleCustomContract(String contractBinary, String contractAddress, Web3j web3j, TransactionManager transactionManager, ContractGasProvider gasProvider) {
+        super(contractBinary, contractAddress, web3j, transactionManager, gasProvider);
+    }
+}

--- a/src/test/projects/issue/63/pom.xml
+++ b/src/test/projects/issue/63/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zuehlke.bc</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Mojo Test Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.web3j</groupId>
+                <artifactId>web3j-maven-plugin</artifactId>
+                <version>4.0.3-SNAPSHOT</version>
+                <configuration>
+                    <packageName>model</packageName>
+                    <sourceDestination>src/test/generated</sourceDestination>
+                    <abiSourceFiles>
+                        <directory>src/test/resources/issue-63</directory>
+                        <includes>
+                            <include>**/*.json</include>
+                        </includes>
+                    </abiSourceFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/issue-63/Greeter.json
+++ b/src/test/resources/issue-63/Greeter.json
@@ -1,0 +1,33 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_greeting",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "greet",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "kill",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
support

### What does this PR do?
Closes issue #63

### Where should the reviewer start?
README.md file changes

### Why is it needed?
Extends capability of plugin usage. ".sol" files are not always provided for wrappers generation. Being able to configure custom parent contract class is also useful.
