### PR TITLE
Ignore wrapper generation for contracts without a binary

### DIFF
--- a/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
+++ b/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
@@ -102,6 +102,14 @@ public class JavaClassGeneratorMojo extends AbstractMojo {
         HashSet<String> contractsKeys = new HashSet<>(contracts.keySet());
         for (String contractFilename : contractsKeys) {
             Map<String, String> contractMetadata = contracts.get(contractFilename);
+
+            String bin = contractMetadata.get("bin");
+            if (bin == null || bin.length() == 0) {
+                contracts.remove(contractFilename);
+                getLog().debug("bin missing for:" + contractFilename);
+                continue;
+            }
+
             String metadata = contractMetadata.get("metadata");
             if (metadata == null || metadata.length() == 0) {
                 contracts.remove(contractFilename);


### PR DESCRIPTION
### What does this PR do?
Stop generating wrapper code for contracts without a binary
