### PR TITLE
Bump Web3j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.6.0</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <web3j.version>4.8.4</web3j.version>
+        <web3j.version>4.8.6</web3j.version>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.6.0</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <web3j.version>4.8.6</web3j.version>
+        <web3j.version>4.8.7</web3j.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
### What does this PR do?

Bump Web3j version to 4.8.7

### Where should the reviewer start?

`pom.xml` file

### Why is it needed?

To avoid issues with big binary string in the generated Java code, fixed by version 4.8.7 of Web3j.
