### PR TITLE
remove interface argument from command compiler

### DIFF
--- a/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
+++ b/src/main/java/org/web3j/mavenplugin/JavaClassGeneratorMojo.java
@@ -281,7 +281,6 @@ public class JavaClassGeneratorMojo extends AbstractMojo {
                 pathPrefixes,
                 SolidityCompiler.Options.ABI,
                 SolidityCompiler.Options.BIN,
-                SolidityCompiler.Options.INTERFACE,
                 SolidityCompiler.Options.METADATA
         );
         if (result.isFailed()) {

--- a/src/main/java/org/web3j/mavenplugin/solidity/SolidityCompiler.java
+++ b/src/main/java/org/web3j/mavenplugin/solidity/SolidityCompiler.java
@@ -130,7 +130,6 @@ public class SolidityCompiler {
 
     public enum Options {
         BIN("bin"),
-        INTERFACE("interface"),
         ABI("abi"),
         METADATA("metadata")
         ;

--- a/src/test/resources/issue-09.sol
+++ b/src/test/resources/issue-09.sol
@@ -1,4 +1,5 @@
-pragma solidity >=0.4.19 < 0.7.0;
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.10 < 0.9.0;
 
 
 library ConvertLib {


### PR DESCRIPTION
### What does this PR do?
Removes 'interface' argument from compiling command. Starting with solc 0.8.10 is no longer accepted after --combined-json flag and gives error.

### Where should the reviewer start?
changed files

### Why is it needed?
Before this version, 0.8.0, it had no effect, the only thing was that the compiling process wasn't returning an error back, but no entry key 'interface' added to the final json.
For testing I ran the compile command on older versions with  and without 'interface' argument and result was the same. ✅ 
