### PR TITLE
chore: bumped web3j version to 4.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.6.1</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <web3j.version>4.8.7</web3j.version>
+        <web3j.version>4.9.4</web3j.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
### What does this PR do?
Updates the underlying web3j dependency to 4.9.4.

### Where should the reviewer start?
Not much to look at :P 

https://github.com/web3j/web3j/releases/tag/v4.9.2 mentions multiple generator related fixes, for example, https://github.com/web3j/web3j/pull/1647

### Why is it needed?
The updates done to web3j since 4.8.7 include multiple fixes to the wrapper generation, and thus by just updating the dependency a lot of related issues are resolved.